### PR TITLE
Fix valueQuantity.units (DSTU 1) -> valueQuantity.unit (DSTU 2)

### DIFF
--- a/load_data.js
+++ b/load_data.js
@@ -112,7 +112,7 @@
     else if (v.valueQuantity.unit === "mmol/L"){
       return parseFloat(v.valueQuantity.value.value)/ 0.10;
     }
-    throw "Unanticipated hsCRP units: " + v.valueQuantity.units;
+    throw "Unanticipated hsCRP units: " + v.valueQuantity.unit;
   };
 
 })(window);


### PR DESCRIPTION
This change fixes the Javascript failure in case if the app encounters a unit ( of an observation returned by the service) which is not supported. Previously in [DSTU 1](http://hl7.org/fhir/DSTU1/datatypes.html#quantity), Quantity defined a `units` attribute but this was renamed to `unit` in [DSTU 2](https://www.hl7.org/fhir/datatypes.html#Quantity).

@kpshek 
@kolkheang 
@koushic88 