### PR TITLE
Add grunt tool config for pushing to gh-pages using Zachs modified grunt-gh-pages tool. Fixes #6

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -73,6 +73,18 @@ module.exports = function (grunt) {
           'build/stylesheets/cardiac_risk.css': ['src/stylesheets/cardiac_risk.css']
         }
       }
+    },
+
+    'gh-pages': {
+      options: {
+        add: true,
+        user: {
+          name: 'Zach Plata',
+          email: 'plata.zach@gmail.com'
+        },
+        move: [{base: 'build', src: '**/*', dest: 'build'}]
+      },
+      src: ['build/**/*', 'index.html', 'launch.html', '.gitignore', 'README.md', 'images/*']
     }
 
   });
@@ -82,5 +94,7 @@ module.exports = function (grunt) {
   grunt.registerTask('test', ['mocha_phantomjs']);
 
   grunt.registerTask('build', ['less', 'cssmin', 'concat', 'jshint', 'uglify']);
+
+  grunt.registerTask('push', ['gh-pages']);
 
 };

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "grunt-contrib-jshint": "^0.10.0",
     "grunt-contrib-less": "^1.1.0",
     "grunt-contrib-uglify": "~0.2.0",
+    "grunt-gh-pages": "git+https://github.com/zplata/grunt-gh-pages.git",
     "grunt-mocha-phantomjs": "^2.0.1",
     "http-server": "^0.9.0",
     "jshint": "^2.9.1",


### PR DESCRIPTION
Currently, once we merge issue branches to the `ascvd` branch, we have to manually take the build files and any other extraneous files that affect the app over to the `gh-pages` branch, where we display the app on a landing page (so others don't have to run the app locally to play around). There's an open source tool called [grunt-gh-pages](https://github.com/tschaub/grunt-gh-pages) that can help do this. Unfortunately, they don't support moving specific files to specific directories in other branches. 

I forked the open source tool and worked in a change [here](https://github.com/zplata/grunt-gh-pages/commit/8b6b3cbb2fac19704474381910471345fda1894f) that allows us to specify a `base` folder and a `dest` folder, and what to specifically push towards the `gh-pages` branch. This will get us what we need out of the tool. I have added my forked version of this tool as a dependency for this right now. The change is actually in a PR to the original open source tool from someone else, so eventually, we could possibly just use the original `grunt-gh-pages ` tool.

@kpshek 
@mjhenkes 
@kolkheang
@koushic88
@shriniketsarkar 